### PR TITLE
Add missing entry in pmbus_cmds array

### DIFF
--- a/src/SMBusCommands.cpp
+++ b/src/SMBusCommands.cpp
@@ -228,6 +228,7 @@ const CommandDesc pmbus_cmds[] = {
 {0xD9, "MFR_SPECIFIC_09",                        Undefined, Undefined,		FT_Undefined},
 {0xDA, "MFR_SPECIFIC_10",                        Undefined, Undefined,		FT_Undefined},
 {0xDB, "MFR_SPECIFIC_11",                        Undefined, Undefined,		FT_Undefined},
+{0xDC, "MFR_SPECIFIC_12",                        Undefined, Undefined,		FT_Undefined},
 {0xDD, "MFR_SPECIFIC_13",                        Undefined, Undefined,		FT_Undefined},
 {0xDE, "MFR_SPECIFIC_14",                        Undefined, Undefined,		FT_Undefined},
 {0xDF, "MFR_SPECIFIC_15",                        Undefined, Undefined,		FT_Undefined},


### PR DESCRIPTION
This fixes an out-of-bound access in GetPMBusCommandDesc. Since
pmbus_cmds had only 256 entries (instead of 257), accessing
pmbus_cmds[0x100] was not correct.

Signed-off-by: Francois Berder <18538310+francois-berder@users.noreply.github.com>