### PR TITLE
move the tile of the "Calculate PEC on packets" from the left side of…

### DIFF
--- a/src/SMBusAnalyzerSettings.cpp
+++ b/src/SMBusAnalyzerSettings.cpp
@@ -23,8 +23,8 @@ SMBusAnalyzerSettings::SMBusAnalyzerSettings() : mSMBDAT( UNDEFINED_CHANNEL ), m
     mDecodeLevelInterface.SetNumber( DL_Signals );
 
     mCalculatePECInterface.SetValue( true );
-    mCalculatePECInterface.SetTitleAndTooltip( "Calculate PEC on packets", "true - calculate PEC, false - no PEC on packets" );
-
+    mCalculatePECInterface.SetTitleAndTooltip( "", "true - calculate PEC, false - no PEC on packets" );
+    mCalculatePECInterface.SetCheckBoxText( "Calculate PEC on packets" );
     // add the interfaces
     AddInterface( &mSMBDATInterface );
     AddInterface( &mSMBCLKInterface );


### PR DESCRIPTION
This change moves the title of the "Calculate PEC on packets" checkbox over to the right side of the checkbox, called the "Checkbox Text"

# Before
![image](https://github.com/user-attachments/assets/d9e7b793-d292-4f07-81b1-c80f22c701d3)

# After
![image](https://github.com/user-attachments/assets/dcaba6d0-c56f-4d14-b61b-8705f9adc1bf)

Note, this should not affect the Logic 2 automation API interface for this analyzer, because the add analyzer functionality will match settings keys based first on setting title, but if the setting title is blank, and the setting is a checkbox, it fall back to the checkbox text.